### PR TITLE
Build web app with nextjs and pnpm

### DIFF
--- a/apps/web/src/components/VideoCanvas.tsx
+++ b/apps/web/src/components/VideoCanvas.tsx
@@ -19,9 +19,11 @@ export default function VideoCanvas() {
 
   // Start camera
   useEffect(() => {
+    let mediaStream: MediaStream | null = null;
+
     const startCamera = async () => {
       try {
-        const mediaStream = await navigator.mediaDevices.getUserMedia({
+        mediaStream = await navigator.mediaDevices.getUserMedia({
           video: { width: 1280, height: 720 },
           audio: true,
         });
@@ -38,8 +40,8 @@ export default function VideoCanvas() {
     startCamera();
 
     return () => {
-      if (stream) {
-        stream.getTracks().forEach((track) => track.stop());
+      if (mediaStream) {
+        mediaStream.getTracks().forEach((track) => track.stop());
       }
     };
   }, []);

--- a/apps/web/src/lib/liveClient.ts
+++ b/apps/web/src/lib/liveClient.ts
@@ -43,6 +43,10 @@ export class LiveClient {
       this.tokenExpireTime = data.expireTime;
       this.newSessionExpireTime = data.newSessionExpireTime;
 
+      if (!this.token) {
+        throw new Error('No token received from server');
+      }
+
       // Set up auto-refresh before newSessionExpireTime (9 minutes)
       this.setupTokenAutoRefresh();
 


### PR DESCRIPTION
Fix Vercel deployment build errors by resolving a TypeScript null-check issue and an ESLint `useEffect` dependency warning.

The TypeScript error occurred because `this.token` was inferred as `string | null` but was directly passed to `GoogleGenerativeAI` which expects `string`. The ESLint warning was due to `stream` being referenced in the `useEffect` cleanup without being in the dependency array, which could lead to stale closures.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d3ef5b8-1527-4fa0-87af-e39b27ee046b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d3ef5b8-1527-4fa0-87af-e39b27ee046b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

