### PR TITLE
Fix nextjs build error in error boundary

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -41,7 +41,7 @@ export class ErrorBoundary extends Component<Props, State> {
             </h1>
             
             <p className="text-gray-600 text-center mb-6">
-              We're sorry, but an unexpected error occurred. Please try refreshing the page.
+              We&apos;re sorry, but an unexpected error occurred. Please try refreshing the page.
             </p>
 
             {this.state.error && process.env.NODE_ENV === 'development' && (


### PR DESCRIPTION
Escape apostrophe in `ErrorBoundary.tsx` to fix ESLint `react/no-unescaped-entities` error.

This fixes the build failure on Render caused by an unescaped apostrophe in the `ErrorBoundary.tsx` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-149388f7-4443-410a-a8b5-ac13258c7a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-149388f7-4443-410a-a8b5-ac13258c7a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

